### PR TITLE
feat(ratings): Implement dynamic property rating screen✅

### DIFF
--- a/lib/3qar/buyer_app/property_rating/controller/cubit/rating_cubit.dart
+++ b/lib/3qar/buyer_app/property_rating/controller/cubit/rating_cubit.dart
@@ -1,0 +1,26 @@
+import 'package:aqar/3qar/buyer_app/property_rating/data/repository/rating_repository.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'rating_state.dart';
+
+class RatingCubit extends Cubit<RatingState> {
+  final RatingRepository ratingRepository;
+
+  RatingCubit(this.ratingRepository) : super(RatingState.initial());
+
+  bool _isRatingsLoaded = false;
+  void fetchRatingsSummaryRelatedToPropertyId(propertyId) async {
+    if (_isRatingsLoaded) return;
+    emit(RatingState.loading());
+    final result =
+        await ratingRepository.getPropertiesRatingsSummary(propertyId);
+
+    result.when(success: (ratings) {
+      _isRatingsLoaded = true;
+
+      emit(RatingState.success(ratings: ratings));
+    }, failure: (error) {
+      emit(RatingState.error(error: error));
+    });
+  }
+}

--- a/lib/3qar/buyer_app/property_rating/controller/cubit/rating_state.dart
+++ b/lib/3qar/buyer_app/property_rating/controller/cubit/rating_state.dart
@@ -1,0 +1,13 @@
+import 'package:aqar/3qar/buyer_app/property_rating/data/model/property_ratings_summary_model.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'rating_state.freezed.dart';
+
+@freezed
+class RatingState with _$RatingState {
+  const factory RatingState.initial() = _Initial;
+  const factory RatingState.loading() = loading;
+  const factory RatingState.success(
+      {required PropertyRatingsSummaryModel ratings}) = Success;
+  const factory RatingState.error({required String error}) = Error;
+}

--- a/lib/3qar/buyer_app/property_rating/controller/cubit/rating_state.freezed.dart
+++ b/lib/3qar/buyer_app/property_rating/controller/cubit/rating_state.freezed.dart
@@ -1,0 +1,629 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'rating_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$RatingState {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(PropertyRatingsSummaryModel ratings) success,
+    required TResult Function(String error) error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(PropertyRatingsSummaryModel ratings)? success,
+    TResult? Function(String error)? error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(PropertyRatingsSummaryModel ratings)? success,
+    TResult Function(String error)? error,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(loading value) loading,
+    required TResult Function(Success value) success,
+    required TResult Function(Error value) error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(loading value)? loading,
+    TResult? Function(Success value)? success,
+    TResult? Function(Error value)? error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(loading value)? loading,
+    TResult Function(Success value)? success,
+    TResult Function(Error value)? error,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $RatingStateCopyWith<$Res> {
+  factory $RatingStateCopyWith(
+          RatingState value, $Res Function(RatingState) then) =
+      _$RatingStateCopyWithImpl<$Res, RatingState>;
+}
+
+/// @nodoc
+class _$RatingStateCopyWithImpl<$Res, $Val extends RatingState>
+    implements $RatingStateCopyWith<$Res> {
+  _$RatingStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of RatingState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+abstract class _$$InitialImplCopyWith<$Res> {
+  factory _$$InitialImplCopyWith(
+          _$InitialImpl value, $Res Function(_$InitialImpl) then) =
+      __$$InitialImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$InitialImplCopyWithImpl<$Res>
+    extends _$RatingStateCopyWithImpl<$Res, _$InitialImpl>
+    implements _$$InitialImplCopyWith<$Res> {
+  __$$InitialImplCopyWithImpl(
+      _$InitialImpl _value, $Res Function(_$InitialImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of RatingState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$InitialImpl implements _Initial {
+  const _$InitialImpl();
+
+  @override
+  String toString() {
+    return 'RatingState.initial()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$InitialImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(PropertyRatingsSummaryModel ratings) success,
+    required TResult Function(String error) error,
+  }) {
+    return initial();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(PropertyRatingsSummaryModel ratings)? success,
+    TResult? Function(String error)? error,
+  }) {
+    return initial?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(PropertyRatingsSummaryModel ratings)? success,
+    TResult Function(String error)? error,
+    required TResult orElse(),
+  }) {
+    if (initial != null) {
+      return initial();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(loading value) loading,
+    required TResult Function(Success value) success,
+    required TResult Function(Error value) error,
+  }) {
+    return initial(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(loading value)? loading,
+    TResult? Function(Success value)? success,
+    TResult? Function(Error value)? error,
+  }) {
+    return initial?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(loading value)? loading,
+    TResult Function(Success value)? success,
+    TResult Function(Error value)? error,
+    required TResult orElse(),
+  }) {
+    if (initial != null) {
+      return initial(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Initial implements RatingState {
+  const factory _Initial() = _$InitialImpl;
+}
+
+/// @nodoc
+abstract class _$$loadingImplCopyWith<$Res> {
+  factory _$$loadingImplCopyWith(
+          _$loadingImpl value, $Res Function(_$loadingImpl) then) =
+      __$$loadingImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$loadingImplCopyWithImpl<$Res>
+    extends _$RatingStateCopyWithImpl<$Res, _$loadingImpl>
+    implements _$$loadingImplCopyWith<$Res> {
+  __$$loadingImplCopyWithImpl(
+      _$loadingImpl _value, $Res Function(_$loadingImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of RatingState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$loadingImpl implements loading {
+  const _$loadingImpl();
+
+  @override
+  String toString() {
+    return 'RatingState.loading()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$loadingImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(PropertyRatingsSummaryModel ratings) success,
+    required TResult Function(String error) error,
+  }) {
+    return loading();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(PropertyRatingsSummaryModel ratings)? success,
+    TResult? Function(String error)? error,
+  }) {
+    return loading?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(PropertyRatingsSummaryModel ratings)? success,
+    TResult Function(String error)? error,
+    required TResult orElse(),
+  }) {
+    if (loading != null) {
+      return loading();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(loading value) loading,
+    required TResult Function(Success value) success,
+    required TResult Function(Error value) error,
+  }) {
+    return loading(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(loading value)? loading,
+    TResult? Function(Success value)? success,
+    TResult? Function(Error value)? error,
+  }) {
+    return loading?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(loading value)? loading,
+    TResult Function(Success value)? success,
+    TResult Function(Error value)? error,
+    required TResult orElse(),
+  }) {
+    if (loading != null) {
+      return loading(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class loading implements RatingState {
+  const factory loading() = _$loadingImpl;
+}
+
+/// @nodoc
+abstract class _$$SuccessImplCopyWith<$Res> {
+  factory _$$SuccessImplCopyWith(
+          _$SuccessImpl value, $Res Function(_$SuccessImpl) then) =
+      __$$SuccessImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({PropertyRatingsSummaryModel ratings});
+}
+
+/// @nodoc
+class __$$SuccessImplCopyWithImpl<$Res>
+    extends _$RatingStateCopyWithImpl<$Res, _$SuccessImpl>
+    implements _$$SuccessImplCopyWith<$Res> {
+  __$$SuccessImplCopyWithImpl(
+      _$SuccessImpl _value, $Res Function(_$SuccessImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of RatingState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? ratings = null,
+  }) {
+    return _then(_$SuccessImpl(
+      ratings: null == ratings
+          ? _value.ratings
+          : ratings // ignore: cast_nullable_to_non_nullable
+              as PropertyRatingsSummaryModel,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SuccessImpl implements Success {
+  const _$SuccessImpl({required this.ratings});
+
+  @override
+  final PropertyRatingsSummaryModel ratings;
+
+  @override
+  String toString() {
+    return 'RatingState.success(ratings: $ratings)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SuccessImpl &&
+            (identical(other.ratings, ratings) || other.ratings == ratings));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, ratings);
+
+  /// Create a copy of RatingState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SuccessImplCopyWith<_$SuccessImpl> get copyWith =>
+      __$$SuccessImplCopyWithImpl<_$SuccessImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(PropertyRatingsSummaryModel ratings) success,
+    required TResult Function(String error) error,
+  }) {
+    return success(ratings);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(PropertyRatingsSummaryModel ratings)? success,
+    TResult? Function(String error)? error,
+  }) {
+    return success?.call(ratings);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(PropertyRatingsSummaryModel ratings)? success,
+    TResult Function(String error)? error,
+    required TResult orElse(),
+  }) {
+    if (success != null) {
+      return success(ratings);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(loading value) loading,
+    required TResult Function(Success value) success,
+    required TResult Function(Error value) error,
+  }) {
+    return success(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(loading value)? loading,
+    TResult? Function(Success value)? success,
+    TResult? Function(Error value)? error,
+  }) {
+    return success?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(loading value)? loading,
+    TResult Function(Success value)? success,
+    TResult Function(Error value)? error,
+    required TResult orElse(),
+  }) {
+    if (success != null) {
+      return success(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class Success implements RatingState {
+  const factory Success({required final PropertyRatingsSummaryModel ratings}) =
+      _$SuccessImpl;
+
+  PropertyRatingsSummaryModel get ratings;
+
+  /// Create a copy of RatingState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$SuccessImplCopyWith<_$SuccessImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$ErrorImplCopyWith<$Res> {
+  factory _$$ErrorImplCopyWith(
+          _$ErrorImpl value, $Res Function(_$ErrorImpl) then) =
+      __$$ErrorImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String error});
+}
+
+/// @nodoc
+class __$$ErrorImplCopyWithImpl<$Res>
+    extends _$RatingStateCopyWithImpl<$Res, _$ErrorImpl>
+    implements _$$ErrorImplCopyWith<$Res> {
+  __$$ErrorImplCopyWithImpl(
+      _$ErrorImpl _value, $Res Function(_$ErrorImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of RatingState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? error = null,
+  }) {
+    return _then(_$ErrorImpl(
+      error: null == error
+          ? _value.error
+          : error // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ErrorImpl implements Error {
+  const _$ErrorImpl({required this.error});
+
+  @override
+  final String error;
+
+  @override
+  String toString() {
+    return 'RatingState.error(error: $error)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ErrorImpl &&
+            (identical(other.error, error) || other.error == error));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, error);
+
+  /// Create a copy of RatingState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ErrorImplCopyWith<_$ErrorImpl> get copyWith =>
+      __$$ErrorImplCopyWithImpl<_$ErrorImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(PropertyRatingsSummaryModel ratings) success,
+    required TResult Function(String error) error,
+  }) {
+    return error(this.error);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(PropertyRatingsSummaryModel ratings)? success,
+    TResult? Function(String error)? error,
+  }) {
+    return error?.call(this.error);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(PropertyRatingsSummaryModel ratings)? success,
+    TResult Function(String error)? error,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(this.error);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(loading value) loading,
+    required TResult Function(Success value) success,
+    required TResult Function(Error value) error,
+  }) {
+    return error(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(loading value)? loading,
+    TResult? Function(Success value)? success,
+    TResult? Function(Error value)? error,
+  }) {
+    return error?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(loading value)? loading,
+    TResult Function(Success value)? success,
+    TResult Function(Error value)? error,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class Error implements RatingState {
+  const factory Error({required final String error}) = _$ErrorImpl;
+
+  String get error;
+
+  /// Create a copy of RatingState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ErrorImplCopyWith<_$ErrorImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/3qar/buyer_app/property_rating/data/model/property_ratings_summary_model.dart
+++ b/lib/3qar/buyer_app/property_rating/data/model/property_ratings_summary_model.dart
@@ -1,0 +1,31 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'rating_model.dart';
+import 'star_rating_count_model.dart';
+
+part 'property_ratings_summary_model.g.dart';
+
+@JsonSerializable()
+class PropertyRatingsSummaryModel {
+  @JsonKey(name: 'reviews')
+  final List<RatingModel>? reviews;
+
+  @JsonKey(name: 'average_rating')
+  final double? averageRating;
+
+  @JsonKey(name: 'total_reviews_count')
+  final int? totalReviewsCount;
+  @JsonKey(name: 'rating_counts')
+  final List<StarRatingCountModel>? ratingCounts;
+
+  const PropertyRatingsSummaryModel({
+    this.reviews,
+    this.averageRating,
+    this.totalReviewsCount,
+    this.ratingCounts,
+  });
+
+  factory PropertyRatingsSummaryModel.fromJson(Map<String, dynamic> json) =>
+      _$PropertyRatingsSummaryModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$PropertyRatingsSummaryModelToJson(this);
+}

--- a/lib/3qar/buyer_app/property_rating/data/model/property_ratings_summary_model.g.dart
+++ b/lib/3qar/buyer_app/property_rating/data/model/property_ratings_summary_model.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'property_ratings_summary_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+PropertyRatingsSummaryModel _$PropertyRatingsSummaryModelFromJson(
+        Map<String, dynamic> json) =>
+    PropertyRatingsSummaryModel(
+      reviews: (json['reviews'] as List<dynamic>?)
+          ?.map((e) => RatingModel.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      averageRating: (json['average_rating'] as num?)?.toDouble(),
+      totalReviewsCount: (json['total_reviews_count'] as num?)?.toInt(),
+      ratingCounts: (json['rating_counts'] as List<dynamic>?)
+          ?.map((e) => StarRatingCountModel.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$PropertyRatingsSummaryModelToJson(
+        PropertyRatingsSummaryModel instance) =>
+    <String, dynamic>{
+      'reviews': instance.reviews,
+      'average_rating': instance.averageRating,
+      'total_reviews_count': instance.totalReviewsCount,
+      'rating_counts': instance.ratingCounts,
+    };

--- a/lib/3qar/buyer_app/property_rating/data/model/rating_model.dart
+++ b/lib/3qar/buyer_app/property_rating/data/model/rating_model.dart
@@ -1,0 +1,39 @@
+import 'package:json_annotation/json_annotation.dart';
+
+import '../../../../sign_up/data/model/user_model.dart';
+
+part 'rating_model.g.dart';
+
+@JsonSerializable()
+class RatingModel {
+  final int? id;
+
+  @JsonKey(name: 'property_id')
+  final int propertyId;
+
+  @JsonKey(name: 'user_id')
+  final String userId;
+  @JsonKey(name: 'profiles')
+  final UserModel? user;
+
+  final double rating;
+  final String? comment;
+
+  @JsonKey(name: 'created_at')
+  final String? createdAt;
+
+  const RatingModel({
+    this.id,
+    required this.propertyId,
+    required this.userId,
+    required this.rating,
+    this.user,
+    this.comment,
+    this.createdAt,
+  });
+
+  factory RatingModel.fromJson(Map<String, dynamic> json) =>
+      _$RatingModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$RatingModelToJson(this);
+}

--- a/lib/3qar/buyer_app/property_rating/data/model/rating_model.g.dart
+++ b/lib/3qar/buyer_app/property_rating/data/model/rating_model.g.dart
@@ -1,0 +1,30 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'rating_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+RatingModel _$RatingModelFromJson(Map<String, dynamic> json) => RatingModel(
+      id: (json['id'] as num?)?.toInt(),
+      propertyId: (json['property_id'] as num).toInt(),
+      userId: json['user_id'] as String,
+      rating: (json['rating'] as num).toDouble(),
+      user: json['profiles'] == null
+          ? null
+          : UserModel.fromJson(json['profiles'] as Map<String, dynamic>),
+      comment: json['comment'] as String?,
+      createdAt: json['created_at'] as String?,
+    );
+
+Map<String, dynamic> _$RatingModelToJson(RatingModel instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'property_id': instance.propertyId,
+      'user_id': instance.userId,
+      'profiles': instance.user,
+      'rating': instance.rating,
+      'comment': instance.comment,
+      'created_at': instance.createdAt,
+    };

--- a/lib/3qar/buyer_app/property_rating/data/model/star_rating_count_model.dart
+++ b/lib/3qar/buyer_app/property_rating/data/model/star_rating_count_model.dart
@@ -1,0 +1,19 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'star_rating_count_model.g.dart';
+
+@JsonSerializable()
+class StarRatingCountModel {
+  final int rating;
+  final int count;
+
+  const StarRatingCountModel({
+    required this.rating,
+    required this.count,
+  });
+
+  factory StarRatingCountModel.fromJson(Map<String, dynamic> json) =>
+      _$StarRatingCountModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$StarRatingCountModelToJson(this);
+}

--- a/lib/3qar/buyer_app/property_rating/data/model/star_rating_count_model.g.dart
+++ b/lib/3qar/buyer_app/property_rating/data/model/star_rating_count_model.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'star_rating_count_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+StarRatingCountModel _$StarRatingCountModelFromJson(
+        Map<String, dynamic> json) =>
+    StarRatingCountModel(
+      rating: (json['rating'] as num).toInt(),
+      count: (json['count'] as num).toInt(),
+    );
+
+Map<String, dynamic> _$StarRatingCountModelToJson(
+        StarRatingCountModel instance) =>
+    <String, dynamic>{
+      'rating': instance.rating,
+      'count': instance.count,
+    };

--- a/lib/3qar/buyer_app/property_rating/data/network/rating_service.dart
+++ b/lib/3qar/buyer_app/property_rating/data/network/rating_service.dart
@@ -1,0 +1,6 @@
+import '../model/property_ratings_summary_model.dart';
+
+abstract class RatingService {
+  Future<PropertyRatingsSummaryModel> getPropertiesRatingsSummary(
+      int propertyId);
+}

--- a/lib/3qar/buyer_app/property_rating/data/network/rating_service_impl.dart
+++ b/lib/3qar/buyer_app/property_rating/data/network/rating_service_impl.dart
@@ -1,0 +1,30 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../model/property_ratings_summary_model.dart';
+import 'rating_service.dart';
+
+class RatingServiceImpl implements RatingService {
+  final supabase = Supabase.instance.client;
+
+  @override
+  Future<PropertyRatingsSummaryModel> getPropertiesRatingsSummary(
+      int propertyId) async {
+    try {
+      final response = await supabase.rpc(
+        'get_property_ratings_summary',
+        params: {'property_id_param': propertyId},
+      ) as List;
+
+      if (response.isEmpty) {
+        return const PropertyRatingsSummaryModel(
+            reviews: [], averageRating: 0.0, totalReviewsCount: 0);
+      }
+
+      final firstResponseItem = response.first as Map<String, dynamic>;
+      return PropertyRatingsSummaryModel.fromJson(firstResponseItem);
+    } catch (error) {
+      return const PropertyRatingsSummaryModel(
+          reviews: [], averageRating: 0.0, totalReviewsCount: 0);
+    }
+  }
+}

--- a/lib/3qar/buyer_app/property_rating/data/repository/rating_repository.dart
+++ b/lib/3qar/buyer_app/property_rating/data/repository/rating_repository.dart
@@ -1,0 +1,19 @@
+import 'package:aqar/3qar/buyer_app/property_rating/data/model/property_ratings_summary_model.dart';
+import 'package:aqar/3qar/buyer_app/property_rating/data/network/rating_service.dart';
+import 'package:aqar/core/network/server_result.dart';
+
+class RatingRepository {
+  final RatingService ratingService;
+  const RatingRepository(this.ratingService);
+
+  Future<ServerResult<PropertyRatingsSummaryModel>> getPropertiesRatingsSummary(
+      int propertyId) async {
+    try {
+      final response =
+          await ratingService.getPropertiesRatingsSummary(propertyId);
+      return ServerResult.success(response);
+    } catch (error) {
+      return ServerResult.failure(error.toString());
+    }
+  }
+}

--- a/lib/3qar/buyer_app/property_rating/property_rating_screen.dart
+++ b/lib/3qar/buyer_app/property_rating/property_rating_screen.dart
@@ -1,0 +1,67 @@
+import 'package:aqar/3qar/buyer_app/property_rating/controller/cubit/rating_cubit.dart';
+import 'package:aqar/3qar/buyer_app/property_rating/controller/cubit/rating_state.dart';
+import 'package:aqar/core/common/widgets/app_bar/main_app_bar.dart';
+import 'package:aqar/core/constants/aqar_colors.dart';
+import 'package:aqar/core/constants/aqar_string.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_spinkit/flutter_spinkit.dart';
+import 'package:lottie/lottie.dart';
+import '../../../core/common/widgets/properties/aqar_rating_bar_indicator.dart';
+import '../../../core/constants/aqar_sizes.dart';
+import '../../../gen/assets.gen.dart';
+import 'widgets/list_of_user_ratings_card.dart';
+import 'widgets/overall_property_rating.dart';
+
+class PropertyRatingScreen extends StatelessWidget {
+  final int propertyId;
+
+  const PropertyRatingScreen({super.key, required this.propertyId});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: MainAqarAppBar(title: AqarString.propertyRating),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: EdgeInsetsDirectional.all(AqarSizes.defaultSpace),
+          child: BlocBuilder<RatingCubit, RatingState>(
+            builder: (context, state) {
+              return state.maybeWhen(
+                loading: () =>
+                    Center(child: SpinKitSpinningLines(color: AqarColors.gold)),
+                success: (ratings) => (ratings.totalReviewsCount == 0)
+                    ? Column(
+                        children: [
+                          Lottie.asset(Assets.images.empty),
+                          Text(AqarString.noRatingYet),
+                        ],
+                      )
+                    : Column(
+                        mainAxisSize: MainAxisSize.min,
+                        spacing: AqarSizes.spaceBtwItems,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(AqarString
+                              .ratingsAndReviewsAreVerifiedAndFromPeopleWhoUseTheSameTypeOfDeviceThatYouUse),
+                          OverallPropertyRating(
+                              ratingCounts: ratings.ratingCounts!,
+                              overalRating:
+                                  ratings.averageRating!.toStringAsFixed(1)),
+                          AqarRatingBarIndicator(
+                              rating: ratings.averageRating ?? 0.0),
+                          Text('${ratings.totalReviewsCount}',
+                              style: Theme.of(context).textTheme.bodySmall),
+                          ListOfUserRatingsCard(ratings: ratings.reviews!),
+                        ],
+                      ),
+                error: (error) => Text(error),
+                orElse: () => SizedBox.shrink(),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/3qar/buyer_app/property_rating/widgets/list_of_user_ratings_card.dart
+++ b/lib/3qar/buyer_app/property_rating/widgets/list_of_user_ratings_card.dart
@@ -1,0 +1,26 @@
+import 'package:aqar/3qar/buyer_app/property_rating/data/model/rating_model.dart';
+import 'package:flutter/material.dart';
+import 'user_review_card.dart';
+
+class ListOfUserRatingsCard extends StatelessWidget {
+  final List<RatingModel> ratings;
+
+  const ListOfUserRatingsCard({
+    super.key,
+    required this.ratings,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: List.generate(
+        ratings.length,
+        (index) => UserReviewCard(
+            key: ValueKey(ratings[index].id),
+            ratings: ratings,
+            isPropertyOwnerReplied: false,
+            index: index),
+      ),
+    );
+  }
+}

--- a/lib/3qar/buyer_app/property_rating/widgets/overall_property_rating.dart
+++ b/lib/3qar/buyer_app/property_rating/widgets/overall_property_rating.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/constants/aqar_sizes.dart';
+import '../data/model/star_rating_count_model.dart';
+import 'rating_progress_indicator.dart';
+
+class OverallPropertyRating extends StatelessWidget {
+  final String overalRating;
+  final List<StarRatingCountModel> ratingCounts;
+
+  const OverallPropertyRating({
+    super.key,
+    required this.overalRating,
+    required this.ratingCounts,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final totalRatings = ratingCounts.fold(0, (sum, item) => sum + item.count);
+
+    return Row(
+      children: [
+        Expanded(
+          flex: 3,
+          child: Text(
+            overalRating,
+            style: Theme.of(context).textTheme.displayLarge,
+          ),
+        ),
+        Expanded(
+          flex: 7,
+          child: Column(
+            spacing: AqarSizes.xs,
+            children: [
+              ...List.generate(5, (index) {
+                final ratingStar = 5 - index;
+                final count = ratingCounts
+                    .firstWhere(
+                      (item) => item.rating == ratingStar,
+                      orElse: () =>
+                          StarRatingCountModel(rating: ratingStar, count: 0),
+                    )
+                    .count;
+
+                final value = totalRatings > 0 ? count / totalRatings : 0.0;
+
+                return RatingProgressIndicator(
+                  text: '$count',
+                  value: value,
+                );
+              }),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/3qar/buyer_app/property_rating/widgets/rating_progress_indicator.dart
+++ b/lib/3qar/buyer_app/property_rating/widgets/rating_progress_indicator.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/constants/aqar_colors.dart';
+import '../../../../core/devices/device_utility.dart';
+
+class RatingProgressIndicator extends StatelessWidget {
+  final String text;
+  final double value;
+  const RatingProgressIndicator(
+      {super.key, required this.text, required this.value});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          flex: 1,
+          child: Text(text, style: Theme.of(context).textTheme.bodyMedium),
+        ),
+        Expanded(
+          flex: 11,
+          child: SizedBox(
+            width: AqarDeviceUtility.getScreenWidth(context) * .8,
+            child: LinearProgressIndicator(
+              backgroundColor: AqarColors.grey,
+              minHeight: 9,
+              value: value,
+              borderRadius: BorderRadius.circular(7),
+              valueColor: AlwaysStoppedAnimation(AqarColors.primary),
+            ),
+          ),
+        )
+      ],
+    );
+  }
+}

--- a/lib/3qar/buyer_app/property_rating/widgets/user_review_card.dart
+++ b/lib/3qar/buyer_app/property_rating/widgets/user_review_card.dart
@@ -1,0 +1,81 @@
+import 'package:aqar/3qar/buyer_app/property_rating/data/model/rating_model.dart';
+import 'package:aqar/core/constants/aqar_string.dart';
+import 'package:flutter/material.dart';
+import 'package:iconsax_flutter/iconsax_flutter.dart';
+
+import '../../../../core/common/widgets/container/rounded_container.dart';
+import '../../../../core/common/widgets/properties/aqar_rating_bar_indicator.dart';
+import '../../../../core/common/widgets/texts/read_more_texts.dart';
+import '../../../../core/constants/aqar_colors.dart';
+import '../../../../core/constants/aqar_sizes.dart';
+import '../../../../core/helpers/helper_functions.dart';
+
+class UserReviewCard extends StatelessWidget {
+  final List<RatingModel> ratings;
+  final int index;
+  final bool isPropertyOwnerReplied;
+  const UserReviewCard(
+      {super.key,
+      required this.ratings,
+      required this.index,
+      required this.isPropertyOwnerReplied});
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = AqarHelperFunctions.isDark(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      spacing: AqarSizes.spaceBtwItems,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Row(
+              spacing: AqarSizes.spaceBtwItems,
+              children: [
+                CircleAvatar(
+                    backgroundImage: NetworkImage(ratings[index].user!.image!)),
+                Text(ratings[index].user!.fullName,
+                    style: Theme.of(context).textTheme.titleLarge),
+              ],
+            ),
+            IconButton(onPressed: () {}, icon: Icon(Iconsax.more_circle_copy))
+          ],
+        ),
+        Row(
+          spacing: AqarSizes.spaceBtwItems,
+          children: [
+            AqarRatingBarIndicator(rating: ratings[index].rating),
+            Text(AqarHelperFunctions.formatDateTime(ratings[index].createdAt!),
+                style: Theme.of(context).textTheme.bodyMedium),
+          ],
+        ),
+        AqarReadMoreText(text: ratings[index].comment!, lines: 3),
+        isPropertyOwnerReplied
+            ? RoundedContainer(
+                bgColor: dark ? AqarColors.darkGrey : AqarColors.light,
+                padding: EdgeInsetsDirectional.all(AqarSizes.md),
+                isText: false,
+                child: Column(
+                  children: [
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Text(AqarString.appTitle,
+                            style: Theme.of(context).textTheme.titleMedium),
+                        Text('26 Feb, 2025',
+                            style: Theme.of(context).textTheme.bodyMedium),
+                      ],
+                    ),
+                    AqarReadMoreText(
+                        text:
+                            'We truly appreciate your continuous support and trust in us. Your 5-star review brightens our day and serves as a constant reminder of why we love what we do.',
+                        lines: 2)
+                  ],
+                ),
+              )
+            : SizedBox.shrink()
+      ],
+    );
+  }
+}

--- a/lib/core/common/widgets/icons/rating_circular_container_with_text_and_icon.dart
+++ b/lib/core/common/widgets/icons/rating_circular_container_with_text_and_icon.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:iconsax_flutter/iconsax_flutter.dart';
+
+import '../../../constants/aqar_colors.dart';
+import '../../../constants/aqar_sizes.dart';
+import '../container/rounded_container.dart';
+import '../row/row_icon_with_title.dart';
+
+class RatingCircularContainerWithTextAndIcon extends StatelessWidget {
+  final String ratingText;
+  final int propertyId;
+  const RatingCircularContainerWithTextAndIcon(
+      {super.key, required this.ratingText, required this.propertyId});
+
+  @override
+  Widget build(BuildContext context) {
+    return RoundedContainer(
+      bgColor: AqarColors.white,
+      isText: false,
+      radius: 25,
+      padding: EdgeInsetsDirectional.symmetric(
+          vertical: AqarSizes.sm, horizontal: AqarSizes.ms),
+      child: RowIconWithTitle(
+          icon: Iconsax.star,
+          text: double.tryParse(ratingText)!.toStringAsFixed(1),
+          iconColor: AqarColors.gold,
+          textColor: AqarColors.black),
+    );
+  }
+}


### PR DESCRIPTION
- This commit introduces a dedicated property rating screen that is dynamically loaded based on each property's unique data. The new screen provides a comprehensive overview of property reviews and is optimized for performance and a smooth user experience.

- Dynamic Data Loading: The screen fetches all rating data for a specific property with a single, efficient API call. This ensures that the data is loaded once and displayed without the need for additional calls.

- Visual Representation: The ratings are visually represented with progress bars, providing an at-a-glance summary of the distribution of star ratings.

- Detailed Reviews: Users can view a list of individual reviews, including the reviewer's name, profile picture, review date, and a detailed comment.

- Performance Optimized: The data is designed to load efficiently, providing a seamless user experience even for properties with a large number of reviews.

![photo_5810144428915018129_y](https://github.com/user-attachments/assets/4536e805-f89a-4098-b4d2-e01036dedb50)

![photo_5810144428915018130_y](https://github.com/user-attachments/assets/9634eb98-c8cf-4c2d-95c4-00d76addf0ce)
