### PR TITLE
feat: add PersonalInformationScreen with profile details, about me editing, and related properties

### DIFF
--- a/lib/3qar/buyer_app/buyer_navigation_menu/controller/buyer_navigation_cubit.dart
+++ b/lib/3qar/buyer_app/buyer_navigation_menu/controller/buyer_navigation_cubit.dart
@@ -1,10 +1,8 @@
 import 'package:aqar/3qar/buyer_app/chat/chat_screen.dart';
 import 'package:aqar/3qar/buyer_app/favorite/favorite_screen.dart';
-import 'package:aqar/3qar/buyer_app/home/controller/home_cubit.dart';
 import 'package:aqar/3qar/buyer_app/home/home_screen.dart';
 import 'package:aqar/3qar/buyer_app/profile/profile_screen.dart';
 import 'package:aqar/3qar/buyer_app/search/search_screen.dart';
-import 'package:aqar/core/service_locator/get_it.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 

--- a/lib/3qar/buyer_app/home/widgets/property_card.dart
+++ b/lib/3qar/buyer_app/home/widgets/property_card.dart
@@ -16,9 +16,13 @@ import '../../../../core/routing/routes.dart';
 
 class PropertyCard extends StatelessWidget {
   final PropertyDetailsModel property;
+  final bool isFavNeeded, isDisplayedInRow;
+
   const PropertyCard({
     super.key,
     required this.property,
+    this.isFavNeeded = true,
+    this.isDisplayedInRow = false,
   });
 
   @override
@@ -54,10 +58,12 @@ class PropertyCard extends StatelessWidget {
                             : const Icon(Icons.image_not_supported),
                       ),
                     ),
-                    Positioned(
-                        top: 10,
-                        right: 10,
-                        child: FavoriteIcon(propertyId: property.id!)),
+                    isFavNeeded
+                        ? Positioned(
+                            top: 10,
+                            right: 10,
+                            child: FavoriteIcon(propertyId: property.id!))
+                        : SizedBox.shrink(),
                   ],
                 ),
                 Expanded(
@@ -69,27 +75,31 @@ class PropertyCard extends StatelessWidget {
                           logo: property.developer!.companyLogoUrl!,
                           propertyLocation: property.location,
                           propertyName: property.propertyName,
+                          isRow: isDisplayedInRow,
                         ),
                         const Spacer(),
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            RowIconWithTitle(
-                              icon: Icons.bed_outlined,
-                              text: '${property.numberOfBeds} Beds',
-                            ),
-                            HeightSeperator(),
-                            RowIconWithTitle(
-                              icon: Icons.shower,
-                              text: '${property.numberOfBathrooms} Bath',
-                            ),
-                            HeightSeperator(),
-                            RowIconWithTitle(
-                              icon: Iconsax.slider_horizontal_1_copy,
-                              text: '${property.area} m',
-                            ),
-                          ],
-                        )
+                        isDisplayedInRow
+                            ? SizedBox.shrink()
+                            : Row(
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
+                                children: [
+                                  RowIconWithTitle(
+                                    icon: Icons.bed_outlined,
+                                    text: '${property.numberOfBeds} Beds',
+                                  ),
+                                  HeightSeperator(),
+                                  RowIconWithTitle(
+                                    icon: Icons.shower,
+                                    text: '${property.numberOfBathrooms} Bath',
+                                  ),
+                                  HeightSeperator(),
+                                  RowIconWithTitle(
+                                    icon: Iconsax.slider_horizontal_1_copy,
+                                    text: '${property.area} m',
+                                  ),
+                                ],
+                              )
                       ],
                     ),
                   ),

--- a/lib/3qar/buyer_app/personal_information/personal_information_screen.dart
+++ b/lib/3qar/buyer_app/personal_information/personal_information_screen.dart
@@ -1,14 +1,11 @@
-import 'package:aqar/3qar/buyer_app/profile/controller/cubit/profile_cubit.dart';
-import 'package:aqar/3qar/buyer_app/profile/controller/cubit/profile_state.dart';
 import 'package:aqar/3qar/buyer_app/profile/data/model/profile_args.dart';
-import 'package:aqar/core/common/widgets/aqar_text_form_field.dart';
 import 'package:aqar/core/common/widgets/images/cached_images.dart';
 import 'package:aqar/core/common/widgets/texts/header_text_with_subtitle.dart';
 import 'package:aqar/core/common/widgets/texts/section_heading.dart';
 import 'package:aqar/core/constants/aqar_sizes.dart';
+import 'package:aqar/core/constants/aqar_string.dart';
 import 'package:aqar/core/helpers/extensions.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:iconsax_flutter/iconsax_flutter.dart';
 
 import '../../../core/common/widgets/row/contact_information_row.dart';
@@ -27,7 +24,7 @@ class PersonalInformationScreen extends StatelessWidget {
     final profile = profileArgs.user;
     return Scaffold(
       appBar: AppBar(
-        title: Text('Personal Information'),
+        title: Text(AqarString.personalInformation),
         leading: IconButton(
           onPressed: () => context.pop(),
           icon: Icon(
@@ -57,16 +54,16 @@ class PersonalInformationScreen extends StatelessWidget {
                 ),
                 HeaderTextwithSubTitle(
                     title: profile.fullName,
-                    subtitle: profile.userType ?? 'Not specified',
+                    subtitle: profile.userType ?? AqarString.notSpecified,
                     isStartAligned: false),
                 const SizedBox(height: AqarSizes.sm),
                 SectionHeading(
-                    text: 'Contact Information', isActionButton: false),
+                    text: AqarString.contactInformation, isActionButton: false),
                 ContactInformationRow(
                     icon: Iconsax.call, text: profile.formatedPhone),
                 ContactInformationRow(
                     icon: Iconsax.message,
-                    text: profile.email ?? 'Not provided'),
+                    text: profile.email ?? AqarString.notSpecified),
                 const SizedBox(height: AqarSizes.sm),
                 AboutMeSectionWithTextField(profileArgs: profileArgs),
                 UserReview(

--- a/lib/3qar/buyer_app/personal_information/widget/about_me_section_with_text_field.dart
+++ b/lib/3qar/buyer_app/personal_information/widget/about_me_section_with_text_field.dart
@@ -1,0 +1,68 @@
+import 'package:aqar/core/constants/aqar_colors.dart';
+import 'package:aqar/core/constants/aqar_sizes.dart';
+import 'package:aqar/core/constants/aqar_string.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:iconsax_flutter/iconsax_flutter.dart';
+
+import '../../../../core/common/widgets/aqar_text_form_field.dart';
+import '../../../../core/common/widgets/texts/section_heading.dart';
+import '../../profile/controller/cubit/profile_cubit.dart';
+import '../../profile/controller/cubit/profile_state.dart';
+import '../../profile/data/model/profile_args.dart';
+
+class AboutMeSectionWithTextField extends StatelessWidget {
+  final ProfileArgs profileArgs;
+  const AboutMeSectionWithTextField({super.key, required this.profileArgs});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<ProfileCubit, ProfileState>(
+      bloc: profileArgs.profileCubit,
+      builder: (context, state) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          spacing: AqarSizes.sm,
+          children: [
+            SectionHeading(
+                text: AqarString.aboutMe,
+                icon: Iconsax.edit_2,
+                onPressed: () {
+                  profileArgs.profileCubit.editAboutMe();
+                },
+                isIcon: true,
+                isActionButton: false),
+            AqarTextFormField(
+              inputType: TextInputType.text,
+              controller: profileArgs.profileCubit.aboutMeController,
+              borderColor: Colors.transparent,
+              isEnabled: profileArgs.profileCubit.isEnabled,
+            ),
+            profileArgs.profileCubit.isEnabled == true
+                ? Container(
+                    width: 80,
+                    height: 40,
+                    decoration: BoxDecoration(
+                        color: AqarColors.green,
+                        borderRadius: BorderRadius.circular(50)),
+                    child: TextButton(
+                      onPressed: () {
+                        profileArgs.profileCubit.updateSingleFieldData().then(
+                            (value) => profileArgs.profileCubit.editAboutMe());
+                      },
+                      child: Text(
+                        AqarString.save,
+                        style: Theme.of(context)
+                            .textTheme
+                            .bodyMedium!
+                            .apply(color: AqarColors.black),
+                      ),
+                    ),
+                  )
+                : SizedBox.shrink(),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/3qar/buyer_app/personal_information/widget/recent_properties_related_to_current_user.dart
+++ b/lib/3qar/buyer_app/personal_information/widget/recent_properties_related_to_current_user.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../core/common/widgets/texts/section_heading.dart';
+import '../../../../core/constants/aqar_sizes.dart';
+import '../../home/widgets/property_card.dart';
+import '../../profile/data/model/profile_args.dart';
+
+class RecentPropertiesRelatedToCurrentUser extends StatelessWidget {
+  final ProfileArgs profileArgs;
+  const RecentPropertiesRelatedToCurrentUser(
+      {super.key, required this.profileArgs});
+
+  @override
+  Widget build(BuildContext context) {
+    final propertiesList = profileArgs.homeCubit.propertiesList;
+    final properties = propertiesList
+        .where((property) => property.ownerId == profileArgs.user.id)
+        .toList();
+    return BlocProvider.value(
+      value: profileArgs.homeCubit,
+      child: Column(
+        children: [
+          SectionHeading(text: 'Recent Properties', isActionButton: false),
+          properties.isEmpty
+              ? Text('No Properties Posted')
+              : ListView.builder(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  itemCount: (properties.length / 2).ceil(),
+                  itemBuilder: (context, index) {
+                    final int firstCardIndex = index * 2;
+                    final int secondCardIndex = firstCardIndex + 1;
+
+                    return Padding(
+                      padding: const EdgeInsets.only(bottom: 16.0),
+                      child: Row(
+                        children: [
+                          Expanded(
+                            child: PropertyCard(
+                              property: properties[firstCardIndex],
+                              isFavNeeded: false,
+                              isDisplayedInRow: true,
+                            ),
+                          ),
+                          const SizedBox(width: AqarSizes.sm),
+                          if (secondCardIndex < properties.length)
+                            Expanded(
+                              child: PropertyCard(
+                                property: properties[secondCardIndex],
+                                isFavNeeded: false,
+                                isDisplayedInRow: true,
+                              ),
+                            )
+                          else
+                            Expanded(child: const SizedBox.shrink()),
+                        ],
+                      ),
+                    );
+                  },
+                ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/3qar/buyer_app/personal_information/widget/user_review.dart
+++ b/lib/3qar/buyer_app/personal_information/widget/user_review.dart
@@ -1,0 +1,51 @@
+import 'package:aqar/core/constants/aqar_string.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../core/common/widgets/loaders/rating_shimmer_loading.dart';
+import '../../../../core/common/widgets/texts/section_heading.dart';
+import '../../profile/controller/cubit/profile_cubit.dart';
+import '../../profile/controller/cubit/profile_state.dart';
+import '../../profile/data/model/profile_enum.dart';
+import '../../property_rating/widgets/list_of_user_ratings_card.dart';
+
+class UserReview extends StatelessWidget {
+  final ProfileCubit profileCubit;
+  final String sellerId;
+  const UserReview(
+      {super.key, required this.profileCubit, required this.sellerId});
+
+  @override
+  Widget build(BuildContext context) {
+    profileCubit.fetchSellerRating(sellerId);
+    return BlocProvider.value(
+      value: profileCubit,
+      child: Column(
+        children: [
+          SectionHeading(text: AqarString.userReviews),
+          BlocBuilder<ProfileCubit, ProfileState>(
+            builder: (context, state) {
+              switch (state.sellerRatingStatus) {
+                case ProfileDataState.loading:
+                  return RatingShimmerLoading();
+                case ProfileDataState.success:
+                  final ratings = state.sellerRatingData;
+                  return ratings.isEmpty
+                      ? Text(
+                          AqarString.noReviewsYet,
+                          style: Theme.of(context).textTheme.bodyMedium,
+                          textAlign: TextAlign.justify,
+                        )
+                      : ListOfUserRatingsCard(ratings: ratings);
+
+                case ProfileDataState.error:
+                  return Text(
+                      state.errorMessage ?? AqarString.somethingWentWrong);
+              }
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/3qar/buyer_app/profile/data/model/profile_args.dart
+++ b/lib/3qar/buyer_app/profile/data/model/profile_args.dart
@@ -1,0 +1,16 @@
+import 'package:aqar/3qar/buyer_app/profile/controller/cubit/profile_cubit.dart';
+import 'package:aqar/3qar/sign_up/data/model/user_model.dart';
+
+import '../../../home/controller/home_cubit.dart';
+
+class ProfileArgs {
+  final UserModel user;
+  final HomeCubit homeCubit;
+  final ProfileCubit profileCubit;
+
+  ProfileArgs({
+    required this.user,
+    required this.homeCubit,
+    required this.profileCubit,
+  });
+}

--- a/lib/3qar/buyer_app/profile/data/model/seller_rating_model.dart
+++ b/lib/3qar/buyer_app/profile/data/model/seller_rating_model.dart
@@ -1,0 +1,39 @@
+import 'package:aqar/3qar/sign_up/data/model/user_model.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'seller_rating_model.g.dart';
+
+@JsonSerializable()
+class SellerRatingModel {
+  final int? id;
+
+  @JsonKey(name: 'seller_id')
+  final String sellerId;
+
+  @JsonKey(name: 'buyer_id')
+  final String buyerId;
+
+  @JsonKey(name: 'profiles')
+  final UserModel? user;
+
+  final double rating;
+  final String? comment;
+
+  @JsonKey(name: 'created_at')
+  final String? createdAt;
+
+  const SellerRatingModel({
+    this.id,
+    required this.sellerId,
+    required this.buyerId,
+    this.user,
+    required this.rating,
+    this.comment,
+    this.createdAt,
+  });
+
+  factory SellerRatingModel.fromJson(Map<String, dynamic> json) =>
+      _$SellerRatingModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SellerRatingModelToJson(this);
+}

--- a/lib/3qar/buyer_app/profile/data/model/seller_rating_model.g.dart
+++ b/lib/3qar/buyer_app/profile/data/model/seller_rating_model.g.dart
@@ -1,0 +1,31 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'seller_rating_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+SellerRatingModel _$SellerRatingModelFromJson(Map<String, dynamic> json) =>
+    SellerRatingModel(
+      id: (json['id'] as num?)?.toInt(),
+      sellerId: json['seller_id'] as String,
+      buyerId: json['buyer_id'] as String,
+      user: json['profiles'] == null
+          ? null
+          : UserModel.fromJson(json['profiles'] as Map<String, dynamic>),
+      rating: (json['rating'] as num).toDouble(),
+      comment: json['comment'] as String?,
+      createdAt: json['created_at'] as String?,
+    );
+
+Map<String, dynamic> _$SellerRatingModelToJson(SellerRatingModel instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'seller_id': instance.sellerId,
+      'buyer_id': instance.buyerId,
+      'profiles': instance.user,
+      'rating': instance.rating,
+      'comment': instance.comment,
+      'created_at': instance.createdAt,
+    };

--- a/lib/3qar/buyer_app/profile/profile_screen.dart
+++ b/lib/3qar/buyer_app/profile/profile_screen.dart
@@ -1,6 +1,7 @@
 import 'package:aqar/3qar/buyer_app/profile/controller/cubit/profile_cubit.dart';
 import 'package:aqar/core/common/widgets/list_tiles/settings_menu_tile.dart';
 import 'package:aqar/core/constants/aqar_sizes.dart';
+import 'package:aqar/core/constants/aqar_string.dart';
 import 'package:aqar/core/service_locator/get_it.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -16,7 +17,7 @@ class ProfileScreen extends StatelessWidget {
     return BlocProvider(
       create: (context) => getIt<ProfileCubit>()..fetchProfileData(),
       child: Scaffold(
-        appBar: AppBar(title: Text('Settings')),
+        appBar: AppBar(title: Text(AqarString.settings)),
         body: SingleChildScrollView(
           child: Padding(
             padding:
@@ -24,23 +25,26 @@ class ProfileScreen extends StatelessWidget {
             child: Column(
               children: [
                 PersonalInformationRowAndAccountDetailsTile(),
-                SettingsMenuTile(icon: Iconsax.sun_1_copy, title: 'App Theme'),
+                SettingsMenuTile(
+                    icon: Iconsax.sun_1_copy, title: AqarString.appTheme),
                 SettingsMenuTile(
                   icon: Iconsax.headphone,
-                  title: 'Support',
+                  title: AqarString.support,
                   trailing: SizedBox.shrink(),
                 ),
                 SettingsMenuTile(
                   icon: Iconsax.info_circle_copy,
-                  title: 'Help & Info',
+                  title: AqarString.helpInfo,
                   trailing: SizedBox.shrink(),
                 ),
                 SizedBox(height: AqarSizes.defaultSpace),
                 SettingsMenuTile(
-                    icon: Iconsax.map_copy, title: 'Change Location'),
+                    icon: Iconsax.map_copy, title: AqarString.changeLocation),
                 SettingsMenuTile(
-                    icon: Iconsax.document_favorite, title: 'Favorited Places'),
-                SettingsMenuTile(icon: Iconsax.location, title: 'Country'),
+                    icon: Iconsax.document_favorite,
+                    title: AqarString.favoritedPlaces),
+                SettingsMenuTile(
+                    icon: Iconsax.location, title: AqarString.country),
               ],
             ),
           ),

--- a/lib/3qar/buyer_app/profile/widget/personal_information_row_and_account_details_tile.dart
+++ b/lib/3qar/buyer_app/profile/widget/personal_information_row_and_account_details_tile.dart
@@ -1,0 +1,100 @@
+import 'package:aqar/3qar/buyer_app/profile/data/model/profile_args.dart';
+import 'package:aqar/core/constants/aqar_string.dart';
+import 'package:aqar/core/helpers/extensions.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:iconsax_flutter/iconsax_flutter.dart';
+
+import '../../../../core/common/widgets/images/cached_images.dart';
+import '../../../../core/common/widgets/list_tiles/settings_menu_tile.dart';
+import '../../../../core/common/widgets/loaders/profile_shimmer_loading.dart';
+import '../../../../core/common/widgets/texts/header_text_with_subtitle.dart';
+import '../../../../core/constants/aqar_colors.dart';
+import '../../../../core/constants/aqar_sizes.dart';
+import '../../../../core/constants/constants.dart';
+import '../../../../core/local_storage/local_storage.dart';
+import '../../../../core/routing/routes.dart';
+import '../../home/controller/home_cubit.dart';
+import '../controller/cubit/profile_cubit.dart';
+import '../controller/cubit/profile_state.dart';
+import '../data/model/profile_enum.dart';
+
+class PersonalInformationRowAndAccountDetailsTile extends StatelessWidget {
+  const PersonalInformationRowAndAccountDetailsTile({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<ProfileCubit, ProfileState>(
+      builder: (context, state) {
+        switch (state.profileDataStatus) {
+          case ProfileDataState.loading:
+            return ProfileShimmerLoading();
+          case ProfileDataState.success:
+            final user = state.userData;
+            return Column(
+              children: [
+                Row(
+                  spacing: AqarSizes.md,
+                  children: [
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(100),
+                      child: CachedImage(
+                        width: 60,
+                        height: 60,
+                        image: user.image!,
+                      ),
+                    ),
+                    HeaderTextwithSubTitle(
+                        title: user.fullName, subtitle: user.email!),
+                    Container(
+                      width: 80,
+                      decoration: BoxDecoration(
+                          border:
+                              Border.all(width: .5, color: AqarColors.darkGrey),
+                          borderRadius: BorderRadius.circular(50)),
+                      child: TextButton(
+                          onPressed: () async {
+                            await context.read<ProfileCubit>().logout();
+                            await SharedPreference.removeSecureString(
+                                Constants.USER_KEY);
+                            isLoggedUser = false;
+                            if (context.mounted) {
+                              context.pushNamedAndRemoveUntil(
+                                Routes.loginOptionScreen,
+                                predicate: (route) => false,
+                              );
+                            }
+                          },
+                          child: Text(AqarString.logout)),
+                    ),
+                  ],
+                ),
+                SizedBox(height: AqarSizes.md),
+                SettingsMenuTile(
+                    icon: Iconsax.profile_remove_copy,
+                    title: AqarString.personalInformation,
+                    onTap: () =>
+                        context.pushNamed(Routes.personalInformationScreen,
+                            arguments: ProfileArgs(
+                              user: user,
+                              homeCubit: context.read<HomeCubit>(),
+                              profileCubit: context.read<ProfileCubit>(),
+                            ))),
+                SettingsMenuTile(
+                    icon: Iconsax.profile_add_copy,
+                    title: AqarString.profileDetails,
+                    onTap: () => context.pushNamed(Routes.profileDetailsScreen,
+                        arguments: ProfileArgs(
+                          user: user,
+                          homeCubit: context.read<HomeCubit>(),
+                          profileCubit: context.read<ProfileCubit>(),
+                        ))),
+              ],
+            );
+          case ProfileDataState.error:
+            return Text(state.errorMessage ?? 'Error with Profile Data');
+        }
+      },
+    );
+  }
+}

--- a/lib/3qar/buyer_app/profile_details/profile_details_screen.dart
+++ b/lib/3qar/buyer_app/profile_details/profile_details_screen.dart
@@ -1,0 +1,28 @@
+import 'package:aqar/core/helpers/extensions.dart';
+import 'package:flutter/material.dart';
+import 'package:iconsax_flutter/iconsax_flutter.dart';
+
+import '../../../core/constants/aqar_colors.dart';
+import '../../../core/helpers/helper_functions.dart';
+
+class ProfileDetailsScreen extends StatelessWidget {
+  const ProfileDetailsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Profile Details'),
+        leading: IconButton(
+          onPressed: () => context.pop(),
+          icon: Icon(
+            Iconsax.arrow_left_2_copy,
+            color: AqarHelperFunctions.isDark(context)
+                ? AqarColors.white
+                : AqarColors.black,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/3qar/buyer_app/property_rating/widgets/list_of_user_ratings_card.dart
+++ b/lib/3qar/buyer_app/property_rating/widgets/list_of_user_ratings_card.dart
@@ -1,4 +1,3 @@
-import 'package:aqar/3qar/buyer_app/property_rating/data/model/rating_model.dart';
 import 'package:flutter/material.dart';
 import '../../../../core/common/widgets/card/user_review_card.dart';
 import '../../../../core/utils/rating_model_args.dart';

--- a/lib/core/common/widgets/card/user_review_card.dart
+++ b/lib/core/common/widgets/card/user_review_card.dart
@@ -62,10 +62,7 @@ class UserReviewCard extends StatelessWidget {
                             style: Theme.of(context).textTheme.bodyMedium),
                       ],
                     ),
-                    AqarReadMoreText(
-                        text:
-                            'We truly appreciate your continuous support and trust in us. Your 5-star review brightens our day and serves as a constant reminder of why we love what we do.',
-                        lines: 2)
+                    AqarReadMoreText(text: '', lines: 2)
                   ],
                 ),
               )

--- a/lib/core/common/widgets/loaders/rating_shimmer_loading.dart
+++ b/lib/core/common/widgets/loaders/rating_shimmer_loading.dart
@@ -1,0 +1,39 @@
+import 'package:aqar/core/common/widgets/loaders/aqar_shimmer.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_rating_bar/flutter_rating_bar.dart';
+
+import '../../../constants/aqar_colors.dart';
+import '../../../constants/aqar_sizes.dart';
+
+class RatingShimmerLoading extends StatelessWidget {
+  const RatingShimmerLoading({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      spacing: AqarSizes.spaceBtwItems,
+      children: [
+        Row(
+          spacing: AqarSizes.spaceBtwItems,
+          children: [
+            AqarShimmerEffect(width: 60, height: 60),
+            AqarShimmerEffect(width: 80, height: 20),
+          ],
+        ),
+        Row(
+          spacing: AqarSizes.spaceBtwItems,
+          children: [
+            RatingBarIndicator(
+              itemBuilder: (_, __) => AqarShimmerEffect(width: 20, height: 20),
+              rating: 5,
+              itemSize: 20,
+              unratedColor: AqarColors.grey,
+            ),
+            AqarShimmerEffect(width: 100, height: 20),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/core/constants/aqar_string.dart
+++ b/lib/core/constants/aqar_string.dart
@@ -70,4 +70,21 @@ class AqarString {
   static const String
       ratingsAndReviewsAreVerifiedAndFromPeopleWhoUseTheSameTypeOfDeviceThatYouUse =
       'Ratings and Reviews are verified and from People Who Use the same type of Device That you use';
+  static const String logout = 'Logout';
+  static const String settings = 'Settings';
+  static const String personalInformation = 'Personal Information';
+  static const String profileDetails = 'Profile Details';
+  static const String appTheme = 'App Theme';
+  static const String aboutMe = 'About Me';
+  static const String support = 'Support';
+  static const String helpInfo = 'Help & Info';
+  static const String changeLocation = 'Change Location';
+  static const String favoritedPlaces = 'Favorited Places';
+  static const String country = 'Country';
+  static const String notSpecified = 'Not specified';
+  static const String noReviewsYet = 'No reviews yet';
+  static const String somethingWentWrong = 'Something went wrong';
+  static const String contactInformation = 'Contact Information';
+  static const String userReviews = 'User Reviews';
+  static const String save = 'Save';
 }


### PR DESCRIPTION
- Implemented PersonalInformationScreen UI with profile image, contact info, and sections
- Added AboutMeSectionWithTextField with edit and save functionality via ProfileCubit
- Integrated UserReview section to fetch and display seller ratings
- Displayed RecentPropertiesRelatedToCurrentUser filtered by ownerId
- Reused ListOfUserRatingsCard for multiple contexts
- Used reusable components: CachedImage, SectionHeading, ContactInformationRow
![photo_5825602600328874490_y](https://github.com/user-attachments/assets/98b3ab05-73a3-4e3d-be9c-a772a2ffe1e5)
![photo_5825602600328874494_y](https://github.com/user-attachments/assets/a57738b3-62f5-43a1-8080-6c25010bf78d)
![photo_5825602600328874493_y](https://github.com/user-attachments/assets/34b0b100-abb3-4d5c-9c43-a88c3ab95d9d)
![photo_5825602600328874492_y](https://github.com/user-attachments/assets/bc5a08ca-f94f-45f2-8f02-3e6490dd0a55)
![photo_5825602600328874491_y](https://github.com/user-attachments/assets/0ad17b61-2520-473e-8c86-0400bff94398)
